### PR TITLE
Diversity Acquisition Functions

### DIFF
--- a/astra/torch/al/__init__.py
+++ b/astra/torch/al/__init__.py
@@ -18,8 +18,5 @@ from astra.torch.al.acquisitions.base import (
 
 # Acquisition functions
 from astra.torch.al.acquisitions.uniform_random import UniformRandomAcquisition
-from astra.torch.al.acquisitions.base import RandomAcquisition
 from astra.torch.al.acquisitions.furthest import Furthest
-
-from astra.torch.al.strategies.random import RandomStrategy
-from astra.torch.al.strategies.diversity import DiversityStrategy
+from astra.torch.al.acquisitions.centroid import Centroid

--- a/astra/torch/al/acquisitions/centroid.py
+++ b/astra/torch/al/acquisitions/centroid.py
@@ -1,0 +1,35 @@
+import torch
+from astra.torch.al.acquisitions.base import DiversityAcquisition
+
+
+class Centroid(DiversityAcquisition):
+    def acquire_scores(self, labeled_embeddings, unlabeled_embeddings, n):
+        """
+        Parameters
+        ----------
+            labeled_embeddings: tensor([n_train, embedding_size])
+                Embedding of the train data
+            unlabeled_embeddings: tensor([n_pool, embedding_size])
+                Embedding of the pool data
+            n: int
+                Number of data points to be selected
+        Returns:
+        ----------
+        idxs: list
+            List of selected data point indices with respect to unlabeled_embeddings
+        """
+        if labeled_embeddings.shape[0] == 0:
+            min_dist = torch.full((unlabeled_embeddings.shape[0],), float("inf"))
+        else:
+            centroid_embedding = torch.mean(labeled_embeddings, dim=0).unsqueeze(0)
+            dist_ctr = torch.cdist(unlabeled_embeddings, centroid_embedding, p=2)
+            min_dist = torch.min(dist_ctr, dim=1)[0]
+        idxs = []
+        for i in range(n):
+            idx = torch.argmax(min_dist)
+            idxs.append(idx.item())
+            dist_new_ctr = torch.cdist(
+                unlabeled_embeddings, unlabeled_embeddings[[idx], :]
+            )
+            min_dist = torch.minimum(min_dist, dist_new_ctr[:, 0])
+        return idxs

--- a/astra/torch/al/acquisitions/random.py
+++ b/astra/torch/al/acquisitions/random.py
@@ -1,7 +1,0 @@
-import torch
-from base import RandomAcquisition
-
-class Random(RandomAcquisition):
-    def acquire_scores(self, logits: torch.Tensor):
-        # logits shape (n_mc_samples, pool_dim, n_classes)
-        return torch.rand(logits.shape[1])

--- a/tests/torch/acquisitions/test_centroid.py
+++ b/tests/torch/acquisitions/test_centroid.py
@@ -1,0 +1,59 @@
+import torch
+from torchvision.datasets import CIFAR10
+
+from astra.torch.models import CNN
+
+from astra.torch.al import Centroid, DiversityStrategy
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def test_centroid():
+    data = CIFAR10(root="data", download=True, train=False)  # "test" for less data
+    inputs = torch.tensor(data.data).float().to(device)
+    outputs = torch.tensor(data.targets).long().to(device)
+
+    # Meta parameters
+    n_pool = 1000
+    indices = torch.randperm(len(inputs))
+    pool_indices = indices[:n_pool]
+    train_indices = indices[n_pool:]
+    n_query_samples = 10
+
+    # Define the acquisition function
+    acquisition = Centroid()
+    strategy = DiversityStrategy(acquisition, inputs, outputs)
+    # Put the strategy on the device
+    strategy.to(device)
+    # Define the model
+    net = CNN(32, 3, 3, [4, 8], [2, 3], 10).to(device)
+
+    def extract_features(net):
+        def feature_extractor(input_tensor):
+            # Initialize features with the input tensor
+            features = input_tensor
+
+            # Apply each layer, activation, and max-pooling
+            for layer in net.feature_extractor:
+                features = layer(features)
+                features = net.activation(features)
+                features = net.max_pool(features)
+            features = net.flatten(features)
+            return features
+
+        return feature_extractor
+
+    # Create a feature extractor callable from the network
+    feature_extractor = extract_features(net)
+
+    # Query the strategy
+    best_indices = strategy.query(
+        feature_extractor, pool_indices, train_indices, n_query_samples=n_query_samples
+    )
+
+    print(best_indices)
+
+    assert best_indices["Centroid"].shape == (n_query_samples,)
+
+
+# test_centroid()

--- a/tests/torch/acquisitions/test_furthest.py
+++ b/tests/torch/acquisitions/test_furthest.py
@@ -49,10 +49,12 @@ def test_furthest():
 
     # Query the strategy
     best_indices = strategy.query(
-        feature_extractor, pool_indices, n_query_samples=n_query_samples
+        feature_extractor, pool_indices, train_indices, n_query_samples=n_query_samples
     )
 
     print(best_indices)
 
     assert best_indices["Furthest"].shape == (n_query_samples,)
 
+
+# test_furthest()


### PR DESCRIPTION
## Implemented Furthest Acquisition and Centroid Acquisition on commit [a6e59ff](https://github.com/sustainability-lab/ASTRA/commit/a6e59fff1be9cfdac90634a335bc4a0b752a3d63). 
### **Files Added:**
1. `astra/torch/al/acquisitions/furthest.py`: contain implementation of Furthest acquisition
2. `astra/torch/al/acquisitions/centroid.py`: contain implementation of Centroid acquisition 
3. `astra/torch/al/strategies/diversity.py`: modified this file as per the need
4. `tests/torch/acquisitions/test_furthest.py`: contains test for furthest acquisition function.
5. `tests/torch/acquisitions/test_centroid.py`: contains test for centroid acquisition function.

**_Passes all test cases, including those already existing(commit: a6e59ff)._** 

### **Explanation:**
1. `furthest.py`: For the furthest acquisition function, we use the furthest_first method of Class `distil.active_learning_strategies.core_set.CoreSet` [link](https://decile-team-distil.readthedocs.io/en/latest/ActStrategy/distil.active_learning_strategies.html#module-distil.active_learning_strategies.core_set) where we pass dummy object strategy as an argument along with labeled_embeddings, unlabeled_embeddings and n. This returns list of indices of n data points that are furthest from all.
2. `centroid.py`: For the centroid acquisition function: For the Centroid Acquisition function, we pass labeled_embeddings, unlabeled_embeddings , and n as input. 

Below lines initializes min_dist as tensor with all values infinity of size [len(n_pool)] when our n_train is 0. 
```python
    if labeled_embeddings.shape[0] == 0:
        min_dist = torch.full((unlabeled_embeddings.shape[0],), float("inf"))
```
Else we find centroid of train data and then pairwise distance between centroid and all pool data.
```python
    else:
        centroid_embedding = torch.mean(labeled_embeddings, dim=0).unsqueeze(0)
        dist_ctr = torch.cdist(unlabeled_embeddings, centroid_embedding, p=2)
        min_dist = torch.min(dist_ctr, dim=1)[0]
```
We find index of n points from pool data, which has max distance. 
```python
    idxs = []
    for i in range(n):
        idx = torch.argmax(min_dist)
        idxs.append(idx.item())
        dist_new_ctr = torch.cdist(unlabeled_embeddings, unlabeled_embeddings[[idx], :])
        min_dist = torch.minimum(min_dist, dist_new_ctr[:, 0])
    return idxs
```
3. `diversity.py`: Since the acquisition function implemented in [link](https://decile-team-distil.readthedocs.io/en/latest/ActStrategy/distil.active_learning_strategies.html#module-distil.active_learning_strategies.core_set) takes (unlabeled_embeddings, labeled_embeddings, n) as parameters, I did same and modified `diversity.py` instead of using `(features, pool_indices, context_indices)` suggested in `diversity.py` of `sustainability-lab/ASTRA`
4. and 5. `test_furthest.py` and `test_centroid`:  Used CIFAR10 to test. Here we want to pass features extractor of model instead of forward pass of model, so I implemented feature extractor as below:
```python
# Define the model
net = CNN(32, 3, 3, [4, 8], [2, 3], 10).to(device)

def extract_features(net):
    def feature_extractor(input_tensor):
        # Initialize features with the input tensor
        features = input_tensor

        # Apply each layer, activation, and max-pooling
        for layer in net.feature_extractor:
            features = layer(features)
            features = net.activation(features)
            features = net.max_pool(features)
        features = net.flatten(features)
        return features

    return feature_extractor

# Create a feature extractor callable from the network
feature_extractor = extract_features(net)
```
This feature_extractor gives us features ie. embedding of input.  
```python
# example: this snippet is not included in code
# input shape: (data_dim, height, width, channels)
input = input.permute(0, 3, 1, 2) #input shape: (data_dim, channels, height, width)
features = feature_extractor(input) # shape (data_dim, feature_dim)
```
We then pass this feature_extractor in `strategy.query()` which gives `best_indices` based on furthest or centroid acquisition provided.
```python
# Query the strategy
best_indices = strategy.query(
    feature_extractor, pool_indices, train_indices, n_query_samples=n_query_samples
)
```