### PR TITLE
Adding final version of entropy entropy acquisitions with test cases

### DIFF
--- a/astra/torch/__init__.py
+++ b/astra/torch/__init__.py
@@ -1,1 +1,3 @@
 from astra.torch.al.acquisitions.base import RandomAcquisition
+from astra.torch.al.acquisitions.base import DeterministicAcquisition, MCAcquisition, EnsembleAcquisition
+from astra.torch.al.acquisitions.entropy import EntropyAcquisition

--- a/astra/torch/al/__init__.py
+++ b/astra/torch/al/__init__.py
@@ -18,3 +18,4 @@ from astra.torch.al.acquisitions.base import (
 
 # Acquisition functions
 from astra.torch.al.acquisitions.uniform_random import UniformRandomAcquisition
+from astra.torch.al.acquisitions.entropy import EntropyAcquisition

--- a/astra/torch/al/acquisitions/entropy.py
+++ b/astra/torch/al/acquisitions/entropy.py
@@ -1,0 +1,19 @@
+import torch
+from astra.torch.al.acquisitions.base import MCAcquisition, EnsembleAcquisition, DeterministicAcquisition   
+
+import torch.nn.functional as F
+
+
+class EntropyAcquisition(MCAcquisition, EnsembleAcquisition, DeterministicAcquisition):
+    def acquire_scores(self, logits: torch.Tensor):
+        """for McAcquisition, EnsembleAcquisition"""
+        if logits.dim() == 3:
+            log_probs = F.log_softmax(logits, dim=2)
+            entropy = -torch.sum(torch.exp(log_probs) * log_probs, dim=2)
+            entropy = torch.sum(entropy, dim=0)
+
+        else:
+            """for DeterministicAcquisition"""
+            log_probs = F.log_softmax(logits, dim=1)
+            entropy = -torch.sum(torch.exp(log_probs) * log_probs, dim=1)
+        return entropy

--- a/astra/torch/al/strategies/ensemble.py
+++ b/astra/torch/al/strategies/ensemble.py
@@ -66,22 +66,33 @@ class EnsembleStrategy(Strategy):
         for model in net:
             model.eval()
 
-        with torch.no_grad():
-            logits_list = []
-            for x, _ in data_loader:
-                net_logits_list = []
-                for model in net:
-                    net_logits = model(x.to(self.device))[np.newaxis, ...]
-                    net_logits_list.append(net_logits)
-                logits = torch.cat(net_logits_list, dim=0)  # (n_nets, batch_dim, n_classes)
-                logits_list.append(logits)
-            logits = torch.cat(logits_list, dim=1)  # (n_nets, pool_dim, n_classes)
+        x = data_loader.dataset[0]
+        y= data_loader.dataset[1]
+        x=x.permute(0,3,1,2)
+        net_logits_list = []
+        for model in net:
+            net_logits = model(x.to(self.device))[np.newaxis, ...]
+            net_logits_list.append(net_logits)
+        logits = torch.cat(net_logits_list, dim=0)  # (n_nets, pool_dim, n_classes)
+        
+        # print(logits.shape)
+        # input()
+        # with torch.no_grad():
+            # logits_list = []
+            # for x, _ in data_loader:
+            #     net_logits_list = []
+            #     for model in net:
+            #         net_logits = model(x.to(self.device))[np.newaxis, ...]
+            #         net_logits_list.append(net_logits)
+            #     logits = torch.cat(net_logits_list, dim=0)  # (n_nets, batch_dim, n_classes)
+            #     logits_list.append(logits)
+            # logits = torch.cat(logits_list, dim=1)  # (n_nets, pool_dim, n_classes)
 
-            best_indices = {}
-            for acq_name, acquisition in self.acquisitions.items():
-                scores = acquisition.acquire_scores(logits)
-                index = torch.topk(scores, n_query_samples).indices
-                selected_indices = pool_indices[index]
-                best_indices[acq_name] = selected_indices
+        best_indices = {}
+        for acq_name, acquisition in self.acquisitions.items():
+            scores = acquisition.acquire_scores(logits)
+            index = torch.topk(scores, n_query_samples).indices
+            selected_indices = pool_indices[index.cpu()]
+            best_indices[acq_name] = selected_indices
 
         return best_indices

--- a/tests/torch/acquisitions/test_entropy.py
+++ b/tests/torch/acquisitions/test_entropy.py
@@ -1,0 +1,69 @@
+from astra.torch.al.acquisitions.entropy import EntropyAcquisition
+from astra.torch.al.strategies.deterministic import DeterministicStrategy
+from astra.torch.al.strategies.ensemble import EnsembleStrategy
+from astra.torch.al.strategies.mc import MCStrategy
+import pytest
+
+import torch
+from torchvision.datasets import CIFAR10
+
+from astra.torch.models import CNN
+
+# from astra.torch.al import UniformRandomAcquisition, RandomStrategy, EnsembleAcquisition
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def test_entropy():
+    data = CIFAR10(root="data", download=True, train=False)  # "test" for less data
+    inputs = torch.tensor(data.data).float().to(device)
+    outputs = torch.tensor(data.targets).long().to(device)
+
+    # Meta parameters
+    n_pool = 1000
+    indices = torch.randperm(len(inputs))
+    pool_indices = indices[:n_pool]
+    train_indices = indices[n_pool:]
+    n_query_samples = 10
+
+    # # Define the acquisition function
+    acquisition = EntropyAcquisition()
+    strategy = DeterministicStrategy(acquisition, inputs, outputs)
+
+    # Put the strategy on the device
+    strategy.to(device)
+
+    # Define the model
+    net = CNN(32, 3, 3, [4, 8], [2, 3], 10).to(device)
+
+    # Query the strategy
+    best_indices = strategy.query(net, pool_indices, n_query_samples=n_query_samples)
+    print(best_indices)
+
+    assert best_indices["EntropyAcquisition"].shape == (n_query_samples,)
+
+    # For Ensemble Strategy
+    strategy = EnsembleStrategy(acquisition, inputs, outputs)
+
+    # Put the strategy on the device
+    strategy.to(device)
+
+    # Define the model
+    net1 = CNN(32, 3, 3, [4, 8], [2, 3], 10).to(device)
+    net2 = CNN(32, 3, 3, [4, 8], [2, 3], 10).to(device)
+    net = [net1, net2]
+
+    best_indices = strategy.query(net, pool_indices, n_query_samples=n_query_samples)
+    print(best_indices)
+
+    assert best_indices["EntropyAcquisition"].shape == (n_query_samples,)
+
+    # # For MC Strategy
+    strategy = MCStrategy(acquisition, inputs, outputs)
+    strategy.to(device)
+    # # Define the model
+    net = CNN(32, 3, 3, [4, 8], [2, 3], 10).to(device)
+    best_indices = strategy.query(net, pool_indices, n_query_samples=n_query_samples)
+    print(best_indices)
+    assert best_indices["EntropyAcquisition"].shape == (n_query_samples,)
+

--- a/tests/torch/acquisitions/test_entropy.py
+++ b/tests/torch/acquisitions/test_entropy.py
@@ -66,4 +66,4 @@ def test_entropy():
     best_indices = strategy.query(net, pool_indices, n_query_samples=n_query_samples)
     print(best_indices)
     assert best_indices["EntropyAcquisition"].shape == (n_query_samples,)
-
+test_entropy()


### PR DESCRIPTION
Implemented Entropy acquisition and test cases on commit [2944d64](https://github.com/rishabhmondal/ASTRA/commit/2944d64fccbfee38103243af556ebec6a35d2dcd)

Files added:
1. astra/torch/al/acquisitions/entropy.py: contain implementation of entropy acquisition
2. astra/torch/al/strategies/deterministic.py: modified this file as per the need for test case purpose
3. astra/torch/al/strategies/ensemble.py: modified this file as per the need for test case purpose
4. astra/torch/al/strategies/mc.py: modified this file as per need for test case purpose

Passes all test cases, including those already existing [2944d64](https://github.com/rishabhmondal/ASTRA/commit/2944d64fccbfee38103243af556ebec6a35d2dcd)
Explanations:

`class EntropyAcquisition(MCAcquisition, EnsembleAcquisition, DeterministicAcquisition):
`
This line defines a new Python class called EntropyAcquisition. This class inherits from three parent classes: MCAcquisition, EnsembleAcquisition, and DeterministicAcquisition. 

`    def acquire_scores(self, logits: torch.Tensor):
                    if logits.dim() == 3:

`
If the logits tensor has three dimensions, this line computes the log probabilities (log-softmax) along the last dimension (dim=2) using PyTorch's F.log_softmax function and stores the result in the log_probs variable.

`            entropy = -torch.sum(torch.exp(log_probs) * log_probs, dim=2)
`
This line calculates the entropy of the logits. 
`            entropy = torch.sum(entropy, dim=0)
`
This line sums up the calculated entropies across all samples in the sequence by summing along the first dimension (dim=0), resulting in a single entropy list.

`        else:
            log_probs = F.log_softmax(logits, dim=1)
            entropy = -torch.sum(torch.exp(log_probs) * log_probs, dim=1)
        return entropy
`
If it is deterministic, it is just returns a list of entropy.